### PR TITLE
fix position for inkdrop 5.8

### DIFF
--- a/styles/code-title.css
+++ b/styles/code-title.css
@@ -1,13 +1,13 @@
 span.code-title {
   color: var(--dark-text-color);
   background-color: rgba(100, 100, 100, 0.175);
-  position: absolute;
   font-size: 75%;
   border-radius: 3px 0 3px 0; /* 3px is `pre` border radius */
   padding: 0.2rem 0.8rem;
   line-height: 1.6rem;
   margin-bottom: -2.2rem;
-  z-index: 2;
+  display: block;
+  width: fit-content;
 }
 
 div.with-title-block {


### PR DESCRIPTION
The title position shifts during scrolling.

![image](https://github.com/elpnt/inkdrop-code-title/assets/42623/45b53665-6515-46fb-85fd-a54ad3201482)

![image](https://github.com/elpnt/inkdrop-code-title/assets/42623/27732104-9e81-4649-a5f4-623e49a824c0)

